### PR TITLE
refactor: No detener el server cuando no se encuentra .env

### DIFF
--- a/config/load_env.go
+++ b/config/load_env.go
@@ -8,6 +8,6 @@ import (
 
 func LoadEnv() {
 	if err := godotenv.Load(".env"); err != nil {
-		log.Fatal("Error loading .env file")
+		log.Print("Please create a .env file in the root directory of the project")
 	}
 }

--- a/main.go
+++ b/main.go
@@ -14,7 +14,6 @@ func init() {
 }
 
 func main() {
-
 	r := gin.Default()
 
 	r.GET("/ping", func(c *gin.Context) {


### PR DESCRIPTION
Esto no hace daño a la ejecución porque la llamada a `os.Getenv` ya devuelve un string vacío si no encuentra la variable, por lo que aun si no existe o si están vacías el comportamiento seria el mismo.

También quite una linea que estaba demas en el main un poco porque si pero esto generalmente no debería pasar.